### PR TITLE
Prevent word splitting in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following shows how to use it when pulled from Docker Hub.
 ### prettier
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/prettier --check --parser=markdown README.md
+docker run --rm -v "$(pwd):/work" tmknom/prettier --check --parser=markdown README.md
 ```
 
 For more information, see [prettier/README.md](/prettier/README.md).
@@ -48,7 +48,7 @@ For more information, see [prettier/README.md](/prettier/README.md).
 ### yamllint
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/yamllint -- .
+docker run --rm -v "$(pwd):/work" tmknom/yamllint -- .
 ```
 
 For more information, see [yamllint/README.md](/yamllint/README.md).
@@ -56,7 +56,7 @@ For more information, see [yamllint/README.md](/yamllint/README.md).
 ### markdownlint
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/markdownlint -- .
+docker run --rm -v "$(pwd):/work" tmknom/markdownlint -- .
 ```
 
 For more information, see [markdownlint/README.md](/markdownlint/README.md).
@@ -64,7 +64,7 @@ For more information, see [markdownlint/README.md](/markdownlint/README.md).
 ### jsonlint
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/jsonlint --compact --quiet foo.json
+docker run --rm -v "$(pwd):/work" tmknom/jsonlint --compact --quiet foo.json
 ```
 
 For more information, see [jsonlint/README.md](/jsonlint/README.md).

--- a/jsonlint/README.md
+++ b/jsonlint/README.md
@@ -34,7 +34,7 @@ For more information, see [GitHub Packages](https://github.com/tmknom/dockerfile
 ### Lint a JSON file
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/jsonlint --compact --quiet foo.json
+docker run --rm -v "$(pwd):/work" tmknom/jsonlint --compact --quiet foo.json
 ```
 
 ### Help

--- a/markdownlint/README.md
+++ b/markdownlint/README.md
@@ -37,13 +37,13 @@ For more information, see [GitHub Packages](https://github.com/tmknom/dockerfile
 ### Lint a Markdown file
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/markdownlint README.md
+docker run --rm -v "$(pwd):/work" tmknom/markdownlint README.md
 ```
 
 ### Lint all Markdown files in a directory
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/markdownlint -- .
+docker run --rm -v "$(pwd):/work" tmknom/markdownlint -- .
 ```
 
 ### Help

--- a/prettier/README.md
+++ b/prettier/README.md
@@ -36,13 +36,13 @@ For more information, see [GitHub Packages](https://github.com/tmknom/dockerfile
 ### Format markdown
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/prettier --write --parser=markdown README.md
+docker run --rm -v "$(pwd):/work" tmknom/prettier --write --parser=markdown README.md
 ```
 
 ### Check format markdown
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/prettier --check --parser=markdown README.md
+docker run --rm -v "$(pwd):/work" tmknom/prettier --check --parser=markdown README.md
 ```
 
 ### Help

--- a/yamllint/README.md
+++ b/yamllint/README.md
@@ -36,13 +36,13 @@ For more information, see [GitHub Packages](https://github.com/tmknom/dockerfile
 ### Lint a YAML file
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/yamllint foo.yml
+docker run --rm -v "$(pwd):/work" tmknom/yamllint foo.yml
 ```
 
 ### Lint all YAML files in a directory
 
 ```shell
-docker run --rm -v $(pwd):/work tmknom/yamllint -- .
+docker run --rm -v "$(pwd):/work" tmknom/yamllint -- .
 ```
 
 ### Help


### PR DESCRIPTION
This should help those who use spaces in dir names, for some reason.